### PR TITLE
Bugfix: return error when go.mod can't be loaded

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -303,9 +303,11 @@ func (api *api) mod(w http.ResponseWriter, r *http.Request, module, version stri
 					}
 				}
 			}
+			w.Write([]byte(fmt.Sprintf("module %s\n", module)))
+			return
 		}
 	}
-	w.Write([]byte(fmt.Sprintf("module %s\n", module)))
+	http.Error(w, err.Error(), http.StatusBadRequest)
 }
 
 func (api *api) zip(w http.ResponseWriter, r *http.Request, module, version string) {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bilus/gomodproxy/1)
<!-- Reviewable:end -->
